### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,45 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @CrossOrigin(origins = "*") //TDB
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @CrossOrigin(origins = "*") //TDB
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @CrossOrigin(origins = "*") //TDB
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o e12fc96d3dc80628c93f5fbc4298f463a1ad0013
**Descrição:** Este PR atualiza o arquivo `src/main/java/com/scalesec/vulnado/CommentsController.java`, modificando a maneira como os endpoints são declarados e como os campos de requisição são manipulados.

**Sumário:** 
- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modificado): 
  - Os verbos HTTP foram atualizados de `@RequestMapping` para `@GetMapping`, `@PostMapping` e `@DeleteMapping` para uma leitura mais intuitiva e concisa.
  - A classe `CommentRequest` foi atualizada para usar métodos getter e setter em vez de campos públicos, melhorando a encapsulação dos dados.
  - Comentários `//TDB` foram adicionados aos cabeçalhos `@CrossOrigin(origins = "*")`. Esses comentários geralmente indicam um trabalho a ser feito no futuro, mas não está claro neste contexto o que precisa ser feito.

**Recomendações:** 
- Recomendo que o revisor verifique se os métodos getter e setter estão funcionando corretamente e se a mudança para `@GetMapping`, `@PostMapping` e `@DeleteMapping` não afetou a funcionalidade dos endpoints.
- É aconselhável esclarecer o que precisa ser feito com os comentários `//TDB` adicionados.

**Explicação de Vulnerabilidades:** 
- Percebi que o código permite requisições de qualquer origem através do cabeçalho `@CrossOrigin(origins = "*")`. Isso pode abrir o aplicativo para Cross-Origin Resource Sharing (CORS) e potenciais ataques de Cross-Site Scripting (XSS). Uma correção poderia ser limitar as origens permitidas para as conhecidas e confiáveis. 

**Por favor, lembre-se que este relatório está no formato Markdown.**