### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CowController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CowController.java
+++ b/src/main/java/com/scalesec/vulnado/CowController.java
@@ -3,12 +3,10 @@ package com.scalesec.vulnado;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 
-import java.io.Serializable;
-
 @RestController
 @EnableAutoConfiguration
 public class CowController {
-    @RequestMapping(value = "/cowsay")
+    @RequestMapping(value = "/cowsay", method = RequestMethod.GET) //Permitindo apenas o método HTTP seguro GET
     String cowsay(@RequestParam(defaultValue = "I love Linux!") String input) {
         return Cowsay.run(input);
     }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o dc2fd45f8114027f51582a2da9fc06c657da01e2

**Descrição:** O Pull Request 6, intitulado '[GFTCodeFix]: Atualização em src/main/java/com/scalesec/vulnado/CowController.java' visa modificar a forma como a aplicação recebe requisições HTTP. Antes, o endpoint "/cowsay" aceitava qualquer tipo de requisição HTTP, mas agora, com essa mudança, apenas requisições GET são permitidas.

**Sumário:** 
- src/main/java/com/scalesec/vulnado/CowController.java (alterado) - O método HTTP padrão para o endpoint "/cowsay" foi modificado de qualquer tipo para apenas GET. O importe "java.io.Serializable" não utilizado foi removido.

**Recomendações:** Recomendo que o revisor teste o comportamento do endpoint "/cowsay" após essa mudança, enviando diferentes tipos de requisições HTTP para confirmar que apenas GET é permitido agora. 

**Explicação de Vulnerabilidades:** Não foram encontradas vulnerabilidades neste commit.