### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  
+  private static final Logger logger = Logger.getLogger(LinkLister.class.getName());
+
+  // private constructor
+  private LinkLister() {
+    // this prevents even the native class from calling this constructor as well
+    throw new AssertionError();
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +35,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 047477a3e4114b24a45dd4f4fc9e118cdab4fa66
                                                
**Descrição:** Este Pull Request introduz modificações no arquivo `LinkLister.java` que visa melhorar a qualidade do código e garantir práticas seguras. 

**Sumário:**
- Arquivo `src/main/java/com/scalesec/vulnado/LinkLister.java` (modificado): 
  - Importou a classe `java.util.logging.Logger` para permitir o registro de logs.
  - Adicionado um Logger privado à classe `LinkLister`.
  - Adicionado um construtor privado que lança um `AssertionError` para prevenir a instanciação da classe `LinkLister`.
  - Substituído o `System.out.println(host)` por `logger.info(host)`, para melhorar o rastreamento de logs.
  - Removido o uso de tipo de parâmetro explícito em `new ArrayList<String>()` para `new ArrayList<>()`, conforme a recomendação do Java 7+ Diamond Operator.
  - Pequenas alterações de formatação e limpeza de código.

**Recomendações:** 
Para o revisor, é importante verificar se a implementação do Logger foi feita corretamente, e se a substituição da impressão na console para o log é adequada para o contexto da aplicação. É também recomendado verificar se a prevenção da instanciação da classe `LinkLister` não interfere na funcionalidade geral do código.
                                                
**Explicação de Vulnerabilidades:** 
Nenhuma vulnerabilidade de segurança foi introduzida ou corrigida neste commit. A modificação centraliza-se principalmente na melhoria da qualidade do código e nas práticas de log.