### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 524a7e3c6ddc62b017975e1b51be4ea258aea60f

**Descrição:** Esta atualização modifica o arquivo LinksController.java, que faz parte do pacote com.scalesec.vulnado. As principais alterações são a limpeza de importações não utilizadas e a definição do método de solicitação HTTP para os endpoints "/links" e "/links-v2".

**Sumario:** 
- Arquivo src/main/java/com/scalesec/vulnado/LinksController.java (modificado): As importações não utilizadas foram removidas para melhorar a legibilidade e a eficiência do código. Os endpoints "/links" e "/links-v2" agora especificam explicitamente que aceitam solicitações GET.

**Recomendações:** Recomendo que o revisor verifique se as importações removidas não são necessárias em nenhum outro lugar do código. Além disso, deve-se testar os endpoints "/links" e "/links-v2" para garantir que eles continuem funcionando conforme esperado após a definição do método de solicitação como GET. 

Por fim, observe que a última linha do arquivo foi modificada para remover a nova linha no final do arquivo, o que geralmente é considerado uma prática não recomendada. Isso pode causar problemas com algumas ferramentas que esperam uma nova linha no final de um arquivo. Sugiro adicionar uma nova linha no final do arquivo.