### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,37 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @CrossOrigin(origins = "*", allowedHeaders = {"x-auth-token"})
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @CrossOrigin(origins = "*", allowedHeaders = {"x-auth-token"})
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @CrossOrigin(origins = "*", allowedHeaders = {"x-auth-token"})
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
+
+  public String getUsername(){
+    return this.username;
+  }
+
+  public String getBody(){
+    return this.body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 0f188240206da702012c90c91598aa2d55a8c3c2

**Descrição:** Este Pull Request modifica a classe CommentsController.java, melhorando a segurança da aplicação ao especificar os headers permitidos nas requisições CORS e ao modificar o modo como os dados são recebidos no método de criação de comentários. Além disso, substituiu as anotações @RequestMapping por anotações mais específicas (@GetMapping, @PostMapping e @DeleteMapping).

**Sumário:**

- src/main/java/com/scalesec/vulnado/CommentsController.java (modificado)
  - Ajuste na anotação @CrossOrigin para permitir apenas headers "x-auth-token"
  - Substituição da anotação @RequestMapping pelos métodos específicos @GetMapping, @PostMapping e @DeleteMapping
  - Modificação no método createComment para usar métodos getters em vez de acessar diretamente os atributos
  - Alteração da classe CommentRequest para tornar os atributos privados e adicionar métodos getters

**Recomendações:** Para o revisor, recomendo verificar se a mudança para métodos getters não afeta outras partes do código que usam a classe CommentRequest. Além disso, seria interessante realizar testes para confirmar se os headers permitidos nas requisições CORS estão funcionando corretamente. 

**Explicação de Vulnerabilidades:** Não foram encontradas novas vulnerabilidades neste pull request. Porém, a mudança para permitir apenas headers "x-auth-token" nas requisições CORS ajuda a proteger contra ataques de falsificação de solicitação entre sites (CSRF).