### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,42 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @CrossOrigin(origins = "*", allowedHeaders = "x-auth-token") // Make sure that enabling CORS is safe here.
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @CrossOrigin(origins = "*", allowedHeaders = "x-auth-token")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @CrossOrigin(origins = "*", allowedHeaders = "x-auth-token")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
+
+  public CommentRequest(String username, String body) {
+    this.username = username;
+    this.body = body;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for d818e52335acfcda3b4aba5dff5a4f813843932c

**Description:** This pull request involves the refactoring and security hardening of the CommentsController.java file within the Vulnado project. The changes made involve the modification of CrossOrigin annotations to allow for specific headers and the replacement of RequestMapping annotations with GetMapping, PostMapping, and DeleteMapping. The CommentRequest class was also refactored to use private variables, with corresponding getter methods and a constructor.

**Summary:** 
- src/main/java/com/scalesec/vulnado/CommentsController.java (modified) - The CrossOrigin annotations were modified to allow the "x-auth-token" header. The RequestMapping annotations for the comments route were replaced with more specific GetMapping, PostMapping, and DeleteMapping annotations. The CommentRequest class was refactored to use private variables with corresponding getter methods and a constructor.

**Recommendations:** The reviewer should ensure the changes do not affect the existing functionality of the application. Test the application with various "x-auth-token" values to ensure the CrossOrigin modifications work as expected. Ensure that the CommentRequest refactoring does not break any existing code that uses it.

**Explanation of Vulnerabilities:** The previous CrossOrigin configuration allowed all headers, which could potentially allow for harmful headers to be included in requests. The new configuration only allows the "x-auth-token" header, reducing this risk. Additionally, the CommentRequest class variables were previously public, allowing for potential misuse. The refactoring to private variables with getter methods and a constructor improves the encapsulation of this class.