### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  // Private constructor to hide the implicit public one
+  private LinkLister() {
+    //TDB
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +34,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for 5631e3790e28f05ce90c68039e8b6a3a5372d21b

**Description:** The changes in this pull request focus on improving code quality and readability in the `LinkLister.java` file. The changes include the addition of a logger for better tracking of events and a private constructor to hide the implicit public one. Furthermore, the code has also been refactored for better readability and conciseness.

**Summary:** 
- `src/main/java/com/scalesec/vulnado/LinkLister.java` (modified): 
  - The logger has been introduced for better tracking and logging of events.
  - An implicit public constructor has been hidden by declaring a private constructor.
  - The way the result list is initialized has been made more concise.
  - System output statements have been replaced with logger information statements to improve the logging system.
  - No newline at the end of file. 

**Recommendations:** 
- Consider adding a comment to explain why the private constructor is empty or add relevant logic if necessary.
- It's a good practice to end the file with a newline to avoid any potential issues with version control systems.
- Ensure that the logging level is set appropriately in the production environment to avoid logging sensitive information.

Please note that these are recommendations and might need to be adjusted based on project-specific standards and practices.