### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  private LinkLister() { // Incluido por GFT AI Impact Bot
+    // Construtor privado para ocultar o público implícito
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>(); // Alterado por GFT AI Impact Bot
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +31,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 51361cd1d54029e0e9bcdb0153aee5a78a06e1da

**Descrição:** Este Pull Request apresenta várias mudanças no arquivo LinkLister.java, onde as modificações foram feitas para melhorar a qualidade do código e tornar o código mais seguro.

**Sumário:** 
- src/main/java/com/scalesec/vulnado/LinkLister.java (modificado)
- Foi adicionado o import para a classe Logger.
- O Logger foi implementado em substituição ao System.out.println para melhorar o registro de logs.
- Foi adicionado um construtor privado para a classe LinkLister para ocultar o construtor público implícito.
- Alterado a inicialização da lista result para usar o operador diamante, isso pode ajudar a tornar o código mais limpo e legível.

**Recomendações:** 
- Verifique a implementação do Logger, certifique-se de que está funcionando corretamente e registrando as informações conforme o esperado.
- Confirme se a adição do construtor privado não está afetando o funcionamento da classe LinkLister em outras partes do sistema.
- Verifique a alteração na inicialização da lista result, garantindo que ainda está funcionando corretamente após a mudança. 

**Explicação de Vulnerabilidades:** 
- Não foram encontradas novas vulnerabilidades no código.