### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,18 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") // Alterado por GFT AI Impact Bot
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 7224b3f5fc6d90d9f7f0e46b0590ee5554dbf41a
                                                
**Descrição:** Este Pull Request faz alterações no arquivo 'LinksController.java', especificamente nos métodos 'links' e 'linksV2'. As modificações incluem a especificação do método HTTP (GET) nas anotações '@RequestMapping' e a remoção de importações não utilizadas.
                                                
**Sumário:** 

- src/main/java/com/scalesec/vulnado/LinksController.java (alterado) - Foram removidos alguns imports não utilizados, especificamente 'org.springframework.boot.*', 'org.springframework.http.HttpStatus' e 'java.io.Serializable'. Além disso, a anotação '@RequestMapping' dos métodos 'links' e 'linksV2' foi modificada para especificar explicitamente o método HTTP como GET e o tipo de produção como 'application/json'. 

**Recomendações:** Recomendo que o revisor confirme se a remoção desses imports não afeta outras partes do código. Além disso, deve-se testar as funções 'links' e 'linksV2' para garantir que elas ainda funcionam conforme esperado após a alteração nas anotações '@RequestMapping'. 

Por favor, note que a falta de uma linha nova no final do arquivo pode causar problemas em algumas ferramentas de desenvolvimento e é geralmente considerado uma má prática. Sugiro adicionar uma linha nova no final do arquivo.