### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LoginController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LoginController.java
+++ b/src/main/java/com/scalesec/vulnado/LoginController.java
@@ -1,10 +1,8 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
-import org.springframework.stereotype.*;
 import org.springframework.beans.factory.annotation.*;
 import java.io.Serializable;
 
@@ -14,11 +12,13 @@ public class LoginController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/login", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  // Corrigido: substituído "@RequestMapping(method = RequestMethod.POST)" por "@PostMapping"
+  // Alterado por GFT AI Impact Bot
+  @CrossOrigin(origins = "*") // Atenção: Certifique-se de que habilitar o CORS é seguro aqui.
+  @PostMapping(value = "/login", produces = "application/json", consumes = "application/json")
   LoginResponse login(@RequestBody LoginRequest input) {
-    User user = User.fetch(input.username);
-    if (Postgres.md5(input.password).equals(user.hashedPassword)) {
+    User user = User.fetch(input.getUsername());
+    if (Postgres.md5(input.getPassword()).equals(user.getHashedPassword())) {
       return new LoginResponse(user.token(secret));
     } else {
       throw new Unauthorized("Access Denied");
@@ -27,13 +27,26 @@ public class LoginController {
 }
 
 class LoginRequest implements Serializable {
-  public String username;
-  public String password;
+  private String username; // Corrigido: tornar username não público e fornecer acessor se necessário. Alterado por GFT AI Impact Bot
+  private String password; // Corrigido: tornar password não público e fornecer acessor se necessário. Alterado por GFT AI Impact Bot
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
 }
 
 class LoginResponse implements Serializable {
-  public String token;
+  private static final String token; // Corrigido: tornar token uma constante estática final ou não pública e fornecer acessor se necessário. Alterado por GFT AI Impact Bot
+
   public LoginResponse(String msg) { this.token = msg; }
+
+  public String getToken() {
+    return token;
+  }
 }
 
 @ResponseStatus(HttpStatus.UNAUTHORIZED)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 6050985f2d8c842061a461424639ad3ca73c9fcc

**Descrição:** Este Pull Request realiza várias mudanças no arquivo `LoginController.java` com o objetivo de melhorar a segurança e a qualidade do código. 

**Sumário:**
- `src/main/java/com/scalesec/vulnado/LoginController.java` (modificado): 
    - Duas importações não utilizadas foram removidas.
    - A anotação `@RequestMapping` foi substituída por `@PostMapping` para tornar o código mais legível e menos propenso a erros.
    - O método `login` agora chama os métodos `getUsername` e `getPassword` em vez de acessar diretamente os campos `username` e `password`.
    - Os campos `username` e `password` da classe `LoginRequest` foram alterados para privados, melhorando o encapsulamento.
    - Métodos getter foram adicionados à classe `LoginRequest` para obter os valores de `username` e `password`.
    - O campo `token` da classe `LoginResponse` foi alterado para privado e agora é uma constante estática final, melhorando o encapsulamento e garantindo que o valor não seja alterado.
    - Um método getter foi adicionado à classe `LoginResponse` para obter o valor de `token`.

**Recomendações:** 
- Revise as mudanças para garantir que nenhuma funcionalidade foi quebrada com as alterações.
- Verifique se a substituição de `@RequestMapping` por `@PostMapping` não tem impacto negativo na funcionalidade.
- Certifique-se de que a alteração de `username` e `password` para privado e a adição de métodos getter não quebram nenhuma outra parte do código que depende deles.
- Verifique se a alteração do campo `token` para uma constante estática final não quebra a funcionalidade.
- Certifique-se de que habilitar o CORS é seguro no contexto atual.

**Explicação de Vulnerabilidades:** 
- Ao tornar os campos `username` e `password` privados, estamos prevenindo que eles sejam acessados diretamente, o que poderia representar uma ameaça à segurança. Ao usar métodos getter, temos mais controle sobre como esses campos podem ser acessados.
- Ao substituir `@RequestMapping` por `@PostMapping`, estamos tornando o código mais específico, o que pode ajudar a prevenir erros e tornar o código mais seguro.
- Ao tornar `token` uma constante estática final, garantimos que seu valor não possa ser alterado, o que pode ajudar a prevenir ataques que visam alterar esse valor.
- Habilitar CORS pode ser perigoso se não for feito corretamente, pois pode permitir que pedidos de origens não confiáveis sejam aceitos.