### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,45 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  // Corrigido: Substituído "@RequestMapping(method = RequestMethod.GET)" por "@GetMapping"
+  // Corrigido: Certifique-se de que habilitar CORS é seguro aqui.
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Alterado por GFT AI Impact Bot
+  @GetMapping(value = "/comments", produces = "application/json") // Alterado por GFT AI Impact Bot
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  // Corrigido: Substituído "@RequestMapping(method = RequestMethod.POST)" por "@PostMapping"
+  // Corrigido: Certifique-se de que habilitar CORS é seguro aqui.
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Alterado por GFT AI Impact Bot
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json") // Alterado por GFT AI Impact Bot
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody()); // Alterado por GFT AI Impact Bot
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  // Corrigido: Substituído "@RequestMapping(method = RequestMethod.DELETE)" por "@DeleteMapping"
+  // Corrigido: Certifique-se de que habilitar CORS é seguro aqui.
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Alterado por GFT AI Impact Bot
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json") // Alterado por GFT AI Impact Bot
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username; // Alterado por GFT AI Impact Bot
+  private String body; // Alterado por GFT AI Impact Bot
+
+  // Corrigido: Torne o username uma constante final estática ou não pública e forneça acessores se necessário.
+  public String getUsername() { // Incluído por GFT AI Impact Bot
+    return username;
+  }
+
+  // Corrigido: Torne o body uma constante final estática ou não pública e forneça acessores se necessário.
+  public String getBody() { // Incluído por GFT AI Impact Bot
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o fa4d5ff240901454ed6c259c5c0e828973bb1e51

**Descrição:** 

Este pull request contém atualizações no arquivo `src/main/java/com/scalesec/vulnado/CommentsController.java`. As principais mudanças estão relacionadas à substituição de anotações @RequestMapping por @GetMapping, @PostMapping e @DeleteMapping e à restrição dos origens do CORS para um site confiável. Além disso, os campos `username` e `body` na classe `CommentRequest` foram tornados privados e foram fornecidos métodos acessores.

**Sumario:** 

- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modificado)
    - Substituído `@RequestMapping(method = RequestMethod.GET)` por `@GetMapping`
    - Substituído `@RequestMapping(method = RequestMethod.POST)` por `@PostMapping`
    - Substituído `@RequestMapping(method = RequestMethod.DELETE)` por `@DeleteMapping`
    - Habilitado CORS somente para `http://trustedwebsite.com`
    - Alterado o método `createComment` para usar os métodos acessores do objeto `input`
    - Tornados os campos `username` e `body` da classe `CommentRequest` privados e fornecidos métodos acessores

**Recomendações:** 

Revisar as mudanças e testar o comportamento dos métodos GET, POST e DELETE após as alterações. Além disso, garantir que o CORS está sendo habilitado de forma segura. 

**Explicação de Vulnerabilidades:** 

A principal vulnerabilidade que estava sendo corrigida aqui é a permissão de origem cruzada (CORS) aberta para qualquer origem. Isso poderia permitir que sites maliciosos fizessem solicitações para a API. Agora, o CORS foi restringido para `http://trustedwebsite.com`. Além disso, os campos `username` e `body` foram tornados privados para encapsular melhor os dados e evitar acessos diretos a esses campos.