### PR TITLE
[GFTCodeFix]:  Update on src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java

### DIFF
--- a/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
+++ b/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
@@ -2,16 +2,29 @@ package com.scalesec.vulnado;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class VulnadoApplicationTests {
 
-	@Test
-	public void contextLoads() {
-	}
+    @LocalServerPort
+    private int port;
 
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void contextLoads() {
+        // Incluido por GFT AI Impact Bot
+        ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:" + port + "/", String.class);
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+    }
 }
-


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 7da660502657a1761f75a9fe1325c5bf42a416cc
**Descrição:** Este commit apresenta uma atualização no arquivo de teste VulnadoApplicationTests.java, no qual foram adicionados novos imports e modificações para permitir testes em um ambiente de porta aleatória e validar a resposta HTTP do servidor.

**Sumário:** 
- Arquivo: src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java (modificado)
    - Importações adicionais para permitir testes em um ambiente de porta aleatória e para facilitar a realização de requisições HTTP.
    - A anotação @SpringBootTest foi modificada para definir o ambiente de teste como uma porta aleatória.
    - Inclusão de um campo de porta local e um objeto restTemplate para a realização de requisições HTTP.
    - O método de teste contextLoads foi modificado para realizar uma requisição GET para o servidor local e verificar se a resposta HTTP é 200.

**Recomendações:** 
- Recomendo a revisão cuidadosa da nova configuração de teste, garantindo que o ambiente de porta aleatória não afeta outros testes.
- Testar essa nova configuração em diferentes ambientes para garantir que a porta aleatória esteja sempre disponível.
- Verificar a possibilidade de parametrizar o endereço do servidor local para tornar o teste mais flexível.

**Explicação de Vulnerabilidades:** Não foram detectadas novas vulnerabilidades nem correções de vulnerabilidades existentes neste commit.