### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger; // Incluido por GFT AI Impact Bot
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName()); // Incluido por GFT AI Impact Bot
+
+  private LinkLister() { // Incluido por GFT AI Impact Bot
+    // Construtor privado para ocultar o público implícito
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>(); // Alterado por GFT AI Impact Bot
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +31,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host); // Alterado por GFT AI Impact Bot
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 0b269c4eb5a50ac1b8b82fd5624a91b0fcf5d269
                                                
**Descrição:** Este pull request apresenta uma série de modificações no arquivo LinkLister.java, focadas principalmente em melhorias de qualidade de código e ajustes de segurança.

**Sumário:**

- **src/main/java/com/scalesec/vulnado/LinkLister.java (modificado)**: 
  - Importação da classe Logger adicionada para permitir o registro de logs da aplicação.
  - Adicionado um construtor privado para a classe LinkLister, de forma a ocultar o construtor público implícito. Isso é uma prática comum em classes de utilitários que contêm apenas métodos estáticos.
  - A declaração de uma nova ArrayList foi simplificada, removendo a especificação redundante do tipo na inicialização.
  - A saída de texto que antes era feita através do System.out.println agora é feita através do LOGGER, proporcionando um melhor controle sobre o registro de logs.
  - A última linha do arquivo, que era uma linha em branco, foi removida.

**Recomendações:** É importante revisar se o uso do LOGGER foi implementado corretamente em todas as partes do código onde é necessário registrar logs. Além disso, verificar se a adição do construtor privado não está quebrando nenhuma funcionalidade existente na aplicação.