### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,41 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @GetMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @PostMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
+  // Alterado por GFT AI Impact Bot: Substituído @RequestMapping por @DeleteMapping
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  // Alterado por GFT AI Impact Bot: tornou username e body privados e adicionou acessadores
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 6d0779149c89fd4d594f69fdf24fd75fcb1aa878

**Descrição:** Este Pull Request realiza uma atualização na classe `CommentsController.java`, focando na modificação de anotações e na reorganização dos atributos da classe `CommentRequest`. 

**Sumário:** 

- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modificado)
   - Substituição da anotação `@RequestMapping` por `@GetMapping` no método `comments`. 
   - Substituição da anotação `@RequestMapping` por `@PostMapping` no método `createComment`.
   - Substituição da anotação `@RequestMapping` por `@DeleteMapping` no método `deleteComment`.
   - Na classe `CommentRequest`, os atributos `username` e `body` foram alterados para privados, com a adição de métodos acessadores (`getUsername` e `getBody`).

**Recomendações:** Recomendo que o revisor verifique se as substituições das anotações estão corretas e se a alteração dos atributos para privado na classe `CommentRequest` não afeta outras partes do código que fazem uso desses atributos. Além disso, o teste unitário deve ser realizado para garantir que as alterações não afetam a funcionalidade original. 

**Explicação de Vulnerabilidades:** Não foram encontradas novas vulnerabilidades nesta revisão.