### PR TITLE
[GFTCodeFix]:  Update on src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java

### DIFF
--- a/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
+++ b/src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java
@@ -1,17 +1,24 @@
 package com.scalesec.vulnado;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class VulnadoApplicationTests {
 
-	@Test
-	public void contextLoads() {
-	}
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void contextLoads() {
+        assertThat(applicationContext).isNotNull(); // Incluido por GFT AI Impact Bot
+    }
 
 }
-


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 0742813a801943f94a7d65cee59587e1e197f1d9

**Descrição:** Este Pull Request traz atualizações para o arquivo src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java, com a adição de uma verificação para garantir que o contexto da aplicação foi carregado corretamente.

**Sumário:** 
- src/test/java/com/scalesec/vulnado/VulnadoApplicationTests.java (alterado): Adicionada uma nova verificação no método de teste contextLoads(). Agora o teste valida se o contexto da aplicação é não nulo. Para isso, foi importada a biblioteca org.assertj.core.api.Assertions e utilizada a afirmação assertThat(applicationContext).isNotNull();.

**Recomendações:** Verifique se os testes estão passando com a nova verificação incluída. A recomendação é verificar se a aplicação está criando o contexto corretamente e se a biblioteca Assertions está devidamente configurada e importada para o projeto. 

Obs: Não foram encontradas vulnerabilidades nessa alteração.