### PR TITLE
[GFTCodeFix]:  Update on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
-FROM openjdk:8
+# Alterado por GFT AI Impact Bot: Usando uma imagem base mais segura e confiável
+FROM maven:3.6.3-openjdk-8-slim
 
+# Alterado por GFT AI Impact Bot: Executando como usuário não root
+RUN useradd -m myuser
+USER myuser
+
+# Alterado por GFT AI Impact Bot: Instalando apenas as dependências necessárias
 RUN apt-get update && \
-    apt-get install build-essential maven default-jdk cowsay netcat -y && \
-    update-alternatives --config javac
-COPY . .
+    apt-get install -y --no-install-recommends netcat && \
+    rm -rf /var/lib/apt/lists/*
 
-CMD ["mvn", "spring-boot:run"]
+# Alterado por GFT AI Impact Bot: Copiando apenas os arquivos necessários
+COPY pom.xml .
+COPY src ./src
+
+# Alterado por GFT AI Impact Bot: Construindo o projeto durante a fase de construção da imagem
+RUN mvn package
+
+# Alterado por GFT AI Impact Bot: Executando o aplicativo com o comando java em vez de mvn
+CMD ["java", "-jar", "target/myapp-0.0.1-SNAPSHOT.jar"]


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 3b41903da7ad16350eff8f08cbcb9ceecc46acc9

**Descrição:** Este Pull Request realiza uma série de atualizações no Dockerfile para melhorar a segurança e eficiência da construção da imagem Docker. 

**Sumário:** 

- Dockerfile (modificado):
  - A imagem base foi alterada de `openjdk:8` para `maven:3.6.3-openjdk-8-slim`, uma imagem mais segura e confiável.
  - O comando `RUN` foi atualizado para executar como um usuário não root.
  - A instalação de dependências foi modificada para instalar apenas as necessárias, reduzindo o tamanho da imagem e possíveis vulnerabilidades.
  - A cópia de arquivos foi ajustada para copiar apenas os arquivos necessários (`pom.xml` e a pasta `src`), em vez de todo o diretório atual.
  - A construção do projeto é agora feita durante a fase de construção da imagem.
  - O comando `CMD` foi alterado para executar o aplicativo com o comando `java` em vez de `mvn`, o que deve melhorar a performance.

**Recomendações:** Recomendo que o revisor verifique se todas as dependências necessárias estão sendo instaladas e se a aplicação ainda funciona como esperado após as alterações. Teste a construção e execução da imagem Docker localmente para garantir que tudo está funcionando corretamente.